### PR TITLE
Switch from OpenSSL to native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MPL-2.0"
 [dependencies]
 serde_json = "0.9"
 rand = "0.3"
-openssl = "0.9"
+native-tls = "0.1.4"
 url = "1.4"
 clippy = { version = "0.0.134", optional = true}
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,6 +1,5 @@
-extern crate url;
 extern crate serde_json;
-extern crate openssl;
+extern crate native_tls;
 
 use std::fmt;
 use std::error;
@@ -8,15 +7,14 @@ use std::io;
 use std::net::TcpStream;
 use std::num::ParseIntError;
 use url::ParseError;
-use openssl::error::ErrorStack;
-use openssl::ssl::HandshakeError;
+use native_tls::HandshakeError;
 
 #[derive(Debug)]
 pub enum HttpError {
     Parse(ParseError),
     IO(io::Error),
     Json(serde_json::Error),
-    ErrStack(ErrorStack),
+    TLS(native_tls::Error),
     SSL(HandshakeError<TcpStream>),
     ParseInt(ParseIntError),
 }
@@ -39,9 +37,9 @@ impl From<serde_json::Error> for HttpError {
     }
 }
 
-impl From<ErrorStack> for HttpError {
-    fn from(err: ErrorStack) -> HttpError {
-        HttpError::ErrStack(err)
+impl From<native_tls::Error> for HttpError {
+    fn from(err: native_tls::Error) -> HttpError {
+        HttpError::TLS(err)
     }
 }
 
@@ -63,7 +61,7 @@ impl fmt::Display for HttpError {
             HttpError::Parse(ref err) => write!(f, "Parse error: {}", err),
             HttpError::IO(ref err) => write!(f, "Parse error: {}", err),
             HttpError::Json(ref err) => write!(f, "Parse error: {}", err),
-            HttpError::ErrStack(ref err) => write!(f, "Parse error: {}", err),
+            HttpError::TLS(ref err) => write!(f, "Parse error: {}", err),
             HttpError::SSL(ref err) => write!(f, "Parse error: {}", err),
             HttpError::ParseInt(ref err) => write!(f, "Parse error: {}", err),
         }
@@ -76,7 +74,7 @@ impl error::Error for HttpError {
             HttpError::Parse(ref err) => err.description(),
             HttpError::IO(ref err) => err.description(),
             HttpError::Json(ref err) => err.description(),
-            HttpError::ErrStack(ref err) => err.description(),
+            HttpError::TLS(ref err) => err.description(),
             HttpError::SSL(ref err) => err.description(),
             HttpError::ParseInt(ref err) => err.description(),
         }
@@ -87,7 +85,7 @@ impl error::Error for HttpError {
             HttpError::Parse(ref err) => Some(err),
             HttpError::IO(ref err) => Some(err),
             HttpError::Json(ref err) => Some(err),
-            HttpError::ErrStack(ref err) => Some(err),
+            HttpError::TLS(ref err) => Some(err),
             HttpError::SSL(ref err) => Some(err),
             HttpError::ParseInt(ref err) => Some(err),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate url;
 extern crate rand;
 extern crate serde_json;
-extern crate openssl;
+extern crate native_tls;
 
 use std::net::TcpStream;
 use std::collections::HashMap;
@@ -18,7 +18,7 @@ use url::{Url, ParseError};
 use consts::*;
 use err::HttpError;
 use response::*;
-use openssl::ssl::{SslMethod, SslConnectorBuilder};
+use native_tls::TlsConnector;
 
 mod err;
 mod consts;
@@ -261,7 +261,7 @@ impl HTTP {
                 None => DEF_SSL_PORT,
             };
             let addr = format!("{}:{}", url, port);
-            let connector = SslConnectorBuilder::new(SslMethod::tls())?.build();
+            let connector = TlsConnector::builder()?.build()?;
             let stream = TcpStream::connect(addr)?;
             let mut stream = connector.connect(&self.host, stream)?;
 


### PR DESCRIPTION
Perhaps a bit confusing with `SSL` and `TLS` error types.

**EDIT:**

How ironic, I did this to support Windows XP, but the native SSL in XP does not support `TLS 1.2`, so I reverted to OpenSSL to make it work.