### PR TITLE
Query-param handling and updating of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MPL-2.0"
 serde_json = "1.0.*"
 rand = "0.3"
 native-tls = "0.1.4"
-url = "1.4"
+url = "1.6"
 clippy = { version = "0.0.134", optional = true}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["rust", "http-client"]
 license = "MPL-2.0"
 
 [dependencies]
-serde_json = "0.9"
+serde_json = "1.0.*"
 rand = "0.3"
 native-tls = "0.1.4"
 url = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,10 +297,14 @@ impl HTTP {
             }
         }
 
+        let path = match self.url.query() {
+            Some(q) => format!("{}?{}", self.url.path(), q),
+            None => self.url.path().to_string(),
+        };
         let mut str = String::new();
         str += &format!("{} {} {}{}",
                         self.method,
-                        self.url.path(),
+                        path,
                         HTTP_VERSION,
                         SEP);
 
@@ -423,4 +427,16 @@ fn organize_header(header: &HashMap<String, String>,
     }
 
     (data, c_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HTTP;
+
+    #[test]
+    fn test_query_params() {
+        let mut http = HTTP::new("http://moo.com/?foo=bar").unwrap();
+        let expected = "GET /?foo=bar".to_string();
+        assert_eq!(http.get().create_request().unwrap()[0 .. expected.len()], expected);
+    }
 }


### PR DESCRIPTION
Trying to `GET http://test.com?foo=bar` resulted in `GET /`. This PR changes that to `GET /?foo=bar`.

Updating dependencies and adds proper query-param handling.

