### PR TITLE
Fix broken tls-build and adding test of tls-functionality.

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,7 +8,7 @@ pub const C_TYPE: [&'static str; 3] = [
 pub const SEP: &'static str = "\r\n";
 
 pub const DEF_PORT: u16 = 80;
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native-tls")]
 pub const DEF_SSL_PORT: u16 = 443;
 pub const DEF_ACCEPT: &'static str = "*/*";
 pub const DEF_CONN: &'static str = "close";

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,15 +1,15 @@
 extern crate serde_json;
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native-tls")]
 extern crate native_tls;
 
 use std::fmt;
 use std::error;
 use std::io;
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native-tls")]
 use std::net::TcpStream;
 use std::num::ParseIntError;
 use url::ParseError;
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native-tls")]
 use native_tls::HandshakeError;
 
 #[derive(Debug)]
@@ -17,9 +17,9 @@ pub enum HttpError {
     Parse(ParseError),
     IO(io::Error),
     Json(serde_json::Error),
-    #[cfg(feature = "native_tls")]
+    #[cfg(feature = "native-tls")]
     TLS(native_tls::Error),
-    #[cfg(feature = "native_tls")]
+    #[cfg(feature = "native-tls")]
     SSL(HandshakeError<TcpStream>),
     ParseInt(ParseIntError),
     MissingFeature(String),
@@ -43,14 +43,14 @@ impl From<serde_json::Error> for HttpError {
     }
 }
 
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native-tls")]
 impl From<native_tls::Error> for HttpError {
     fn from(err: native_tls::Error) -> HttpError {
         HttpError::TLS(err)
     }
 }
 
-#[cfg(feature = "native_tls")]
+#[cfg(feature = "native-tls")]
 impl From<HandshakeError<TcpStream>> for HttpError {
     fn from(err: HandshakeError<TcpStream>) -> HttpError {
         HttpError::SSL(err)
@@ -69,9 +69,9 @@ impl fmt::Display for HttpError {
             HttpError::Parse(ref err) => write!(f, "Parse error: {}", err),
             HttpError::IO(ref err) => write!(f, "Parse error: {}", err),
             HttpError::Json(ref err) => write!(f, "Parse error: {}", err),
-            #[cfg(feature = "native_tls")]
+            #[cfg(feature = "native-tls")]
             HttpError::TLS(ref err) => write!(f, "Parse error: {}", err),
-            #[cfg(feature = "native_tls")]
+            #[cfg(feature = "native-tls")]
             HttpError::SSL(ref err) => write!(f, "Parse error: {}", err),
             HttpError::ParseInt(ref err) => write!(f, "Parse error: {}", err),
             HttpError::MissingFeature(ref err) => write!(f, "Missing feature: {}", err),
@@ -85,9 +85,9 @@ impl error::Error for HttpError {
             HttpError::Parse(ref err) => err.description(),
             HttpError::IO(ref err) => err.description(),
             HttpError::Json(ref err) => err.description(),
-            #[cfg(feature = "native_tls")]
+            #[cfg(feature = "native-tls")]
             HttpError::TLS(ref err) => err.description(),
-            #[cfg(feature = "native_tls")]
+            #[cfg(feature = "native-tls")]
             HttpError::SSL(ref err) => err.description(),
             HttpError::ParseInt(ref err) => err.description(),
             HttpError::MissingFeature(ref err) => err,
@@ -99,9 +99,9 @@ impl error::Error for HttpError {
             HttpError::Parse(ref err) => Some(err),
             HttpError::IO(ref err) => Some(err),
             HttpError::Json(ref err) => Some(err),
-            #[cfg(feature = "native_tls")]
+            #[cfg(feature = "native-tls")]
             HttpError::TLS(ref err) => Some(err),
-            #[cfg(feature = "native_tls")]
+            #[cfg(feature = "native-tls")]
             HttpError::SSL(ref err) => Some(err),
             HttpError::ParseInt(ref err) => Some(err),
             HttpError::MissingFeature(ref _err) => None,

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -46,4 +46,13 @@ mod test {
 
         assert!(!string.is_empty(), "Response shouldn't be empty");
     }
+    #[cfg(feature = "native-tls")]
+    #[test]
+    fn get_tls_response() {
+        let mut http = HTTP::new("https://google.com/").unwrap();
+        let response = http.get().send().unwrap();
+        let string = response.as_str();
+
+        assert!(!string.is_empty(), "Response shouldn't be empty");
+    }
 }


### PR DESCRIPTION
My last PR broke tls functionality due to a mixup of `_` and `-`. This fixes that error and adds a test to actually verify working TLS-functionality.

Verify with

```
cargo test
```
and
```
cargo test --no-default-features
```