### PR TITLE
Add danger_accept_invalid_certs function to allow invalid SSL certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ default = ["native-tls"]
 [dependencies]
 serde_json = "1.0.*"
 rand = "0.3"
-native-tls = { version = "0.1.4", optional = true }
+native-tls = { version = "0.2.1", optional = true }
 url = "1.6"
 clippy = { version = "0.0.134", optional = true}


### PR DESCRIPTION
This allows knock to work with sites that have invalid certs. E.g self signed certificates.