### PR TITLE
Use HTTP/1.0 instead of 1.1 as there is no transfer-encoding chunking support

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,4 +1,4 @@
-pub const HTTP_VERSION: &'static str = "HTTP/1.1";
+pub const HTTP_VERSION: &'static str = "HTTP/1.0";
 pub const CL_METHODS: [&'static str; 2] = ["POST", "PUT"];
 pub const C_TYPE: [&'static str; 3] = [
     "application/json",


### PR DESCRIPTION
Knock does not support chunked transfer-encoding, which is a requirement of HTTP/1.1. This PR makes knock use the HTTP/1.0 protocol instead.